### PR TITLE
chore: Remove Local Copy on Cloudinary Upload

### DIFF
--- a/server/utils/cloudinary.ts
+++ b/server/utils/cloudinary.ts
@@ -1,5 +1,7 @@
-import { v2 as cloudinary,UploadApiResponse } from 'cloudinary';
+import { v2 as cloudinary, UploadApiResponse } from 'cloudinary';
 import fs from 'fs';
+import dotenv from 'dotenv';
+dotenv.config();
 
 interface CloudinaryConfig {
   cloud_name: string;
@@ -7,24 +9,27 @@ interface CloudinaryConfig {
   api_secret: string;
 }
 
-export const uploadOnCloudinary = async (localFilePath: string) => {
+const cloudinaryConfig: Readonly<CloudinaryConfig> = {
+  cloud_name: process.env.CLOUDINARY_CLOUD_NAME!,
+  api_key: process.env.CLOUDINARY_API_KEY!,
+  api_secret: process.env.CLOUDINARY_API_SECRET!
+};
+
+cloudinary.config(cloudinaryConfig);
+
+export const uploadOnCloudinary = async (
+  localFilePath: string
+): Promise<UploadApiResponse | null> => {
   try {
     if (!localFilePath) return null;
     const response = await cloudinary.uploader.upload(localFilePath, {
       resource_type: 'auto'
     });
-    console.log('File has been uploaded', response.url);
+    fs.unlinkSync(localFilePath);
     return response;
   } catch (error) {
     fs.unlinkSync(localFilePath);
     console.log('Removed file from server ', error);
+    return null;
   }
 };
-
-const cloudinaryConfig: CloudinaryConfig = {
-  cloud_name: process.env.CLOUDINARY_CLOUD_NAME || '',
-  api_key: process.env.CLOUDINARY_API_KEY || '',
-  api_secret: process.env.CLOUDINARY_API_SECRET || ''
-};
-
-cloudinary.config(cloudinaryConfig);


### PR DESCRIPTION
This pull request simplifies file management by removing local copies after successful uploads to Cloudinary. This routine task enhances efficiency and maintains a clean server environment.