### PR TITLE
fix: Export Previously Unexported Class

### DIFF
--- a/server/utils/apiError.ts
+++ b/server/utils/apiError.ts
@@ -1,4 +1,4 @@
-class apiError extends Error {
+export class apiError extends Error {
   statusCode: number;
   success: boolean;
   constructor(message: string, statusCode: number) {


### PR DESCRIPTION
Exported a class which was being used at other locations but was not being exported 