### PR TITLE
feat : Retrieve Single Video Route and Controller

### DIFF
--- a/server/controllers/video.controller.ts
+++ b/server/controllers/video.controller.ts
@@ -28,10 +28,23 @@ export const publishVideo = asyncHandler(
       description,
       videoFile: video?.url,
       thumbnail: thumbnail?.url,
-      duration : video?.duration
+      duration: video?.duration
     });
 
     await newVideo.save();
     res.status(201).json(new apiResponse(newVideo, 201, 'Video published'));
+  }
+);
+
+export const getSingleVideo = asyncHandler(
+  async (req: UserRequest, res: Response) => {
+
+    const { videoId } = req.params;
+    if (!videoId) throw new apiError('Video ID is required', 400);
+
+    const video = await Video.findById(videoId).populate('owner', 'username');
+    if (!video) throw new apiError('Video not found', 404);
+
+    res.status(200).json(new apiResponse(video, 200, 'Video retrieved'));
   }
 );

--- a/server/routes/video.route.ts
+++ b/server/routes/video.route.ts
@@ -1,6 +1,6 @@
 import { Router } from 'express';
 import { verifyJWT } from '../middlewares/auth.middleware';
-import { publishVideo } from '../controllers/video.controller';
+import { getSingleVideo, publishVideo } from '../controllers/video.controller';
 import { upload } from '../middlewares/multer.middleware';
 
 export const router = Router();
@@ -20,5 +20,7 @@ router.post(
   ]),
 publishVideo
 );
+
+router.get('/video/:videoId', verifyJWT, getSingleVideo);
 
 export const video = router;


### PR DESCRIPTION
### Feature: Retrieve Single Video Endpoint

**Overview:**

This pull request introduces a new feature for retrieving details about a single video through the `getSingleVideo` endpoint. Users can access specific video information by providing the video ID in the request. The implementation includes database queries, error handling for invalid video IDs, and a response format that provides comprehensive details about the requested video.

**Key Changes:**

1. **New Endpoint and Controller:**
   - Added a new endpoint, `getSingleVideo`, and the corresponding controller to handle single video retrieval.

2. **Video ID Validation:**
   - Implemented logic to validate and handle cases where the provided video ID is invalid or not found.

3. **Database Query:**
   - Utilized Mongoose to query the database for the details of the specified video.

4. **Response Structure:**
   - Defined a structured response using the `apiResponse` class to provide detailed information about the requested video.